### PR TITLE
Fix for Deferred being fired twice.

### DIFF
--- a/txyam/factory.py
+++ b/txyam/factory.py
@@ -39,7 +39,7 @@ class MemCacheClientFactory(ReconnectingClientFactory):
         ReconnectingClientFactory.clientConnectionFailed(self, connector, reason)
 
 
-   def connectionMade(self):
+    def connectionMade(self):
         if self.deferred is not None:
             self.deferred.callback(self)
             self.deferred = None


### PR DESCRIPTION
When the library goes into reconnect mode connectionMade can be called twice, once for the original connection and once for the new connection. This is causing the deferred to be fired twice when something goes wrong with memcached.

My understanding is that when using ReconnectingFactory the factory's buildProtocol gets called for each new connection. This means the single deferred is being returned multiple times from buildProtocol.

I'm not totally sure on the best fix, this one at least stops the deferred from being multi-fired.
