### PR TITLE
Update client.py

### DIFF
--- a/txyam/client.py
+++ b/txyam/client.py
@@ -39,6 +39,7 @@ class YamClient:
         @param hosts: A C{list} of C{tuple}s containing hosts and ports.
         """
         self.hosts = hosts
+        self.hosts_hashring = HashRing(hosts)
         if connect:
             self.connect()
 
@@ -53,7 +54,7 @@ class YamClient:
         log.msg("Using %i active hosts" % len(hosts))
         if len(hosts) == 0:
             raise NoServerError("No connected servers remaining.")
-        return HashRing(hosts).get_node(key)
+        return self.hosts_hashring.get_node(key)
 
 
     @inlineCallbacks


### PR DESCRIPTION
getClient is called many times, so hashes are recalculated again and again.. 
Please consider to put HashRing function in **init** so it's called only once..
This change improves perfomance by x10 with only two hosts given..
Thanks a lot for the open source!!!
